### PR TITLE
sw: resolve write broken_pipe issue when running ASE in regression mode

### DIFF
--- a/ase/sw/app_backend.c
+++ b/ase/sw/app_backend.c
@@ -704,6 +704,10 @@ void session_deinit(void)
 		// Um-mapping CSR region
 		ASE_MSG("Deallocating MMIO map\n");
 		if (mmio_exist_status == ESTABLISHED) {
+			// Waiting for pending MMIO requests to complete
+			while (count_mmio_tid_used() != 0) {
+				sleep(1);
+			}
 			cleanup_mmio();
 			mmio_exist_status = NOT_ESTABLISHED;
 


### PR DESCRIPTION
Broken pipe caused by ASE's MMIO respond coming in between app backend initializing
and deinitialing, when the named pipes are closed and not monitored. This change makes
`fpgaClose()` wait for ASE's responses to all outstanding MMIO requests.