### PR TITLE
sw: make sure app process exits cleanly after regression mode run

### DIFF
--- a/ase/sw/protocol_backend.c
+++ b/ase/sw/protocol_backend.c
@@ -1422,6 +1422,14 @@ void start_simkill_countdown(void)
 	ASE_DBG("Caught a SIG\n");
 #endif
 
+	// In regression mode app side stucks in mqueue_recv during deinitialization
+	// Therefore, send a complete message to allow app to cleanly exit
+	if (cfg->ase_mode == ASE_MODE_REGRESSION) {
+		mqueue_send(sim2app_portctrl_rsp_tx,
+				completed_str_msg,
+				ASE_MQ_MSGSIZE);
+	}
+
 	// Close and unlink message queue
 	ASE_MSG("Closing message queue and unlinking...\n");
 


### PR DESCRIPTION
The app end's `session_deinit` function will try to send `ASE_SIMKILL` command to the protocol end, and wait for the protocol end's response. When the last run of the DUT finished in regression mode, the protocol end somehow doesn't send response to app end's `ASE_SIMKILL`, causing the app end process not terminating, which then leads to lingering .nfsxxxx files in the work directory. This causes problems in subsequent run of ASE if the user doesn't clean up the .nfsxxxx files by killing the app end process.

This change attempts to fix this issue by sending response to app end's `ASE_SIMKILL` in `start_simkill_countdown`. The response is sent in this function instead of in `ase_listener` in order to handle ctrl-C signals sent in regression mode.