### PR TITLE
Use rtl_src_config --sim-vhdl to parse VHDL source lists

### DIFF
--- a/ase/Makefile
+++ b/ase/Makefile
@@ -298,7 +298,7 @@ endif
 #########################################################################
 ## VHDL compile
 SNPS_VHDLAN_OPT?=
-SNPS_VHDLAN_OPT+= -nc -verbose -full64
+SNPS_VHDLAN_OPT+= -nc -verbose -full64 -smart_order
 SNPS_VHDLAN_OPT+= -work $(WORK)
 
 ## Verilog compile


### PR DESCRIPTION
A new rtl_src_config option creates separate source file lists for Verilog and VHDL modes. Update the simulator environment generator to match.