### PR TITLE
sw: extend MMIO address space to 1GB

### DIFF
--- a/ase/api/src/mmio.c
+++ b/ase/api/src/mmio.c
@@ -68,7 +68,7 @@ fpga_result __FPGA_API__ ase_fpgaWriteMMIO32(fpga_handle handle,
 			FPGA_MSG("Misaligned MMIO access");
 			return FPGA_INVALID_PARAM;
 		} else {
-			if (offset > MMIO_AFU_OFFSET) {
+			if (offset > MMIO_AFU_LENGTH) {
 				FPGA_MSG("Offset out of bounds");
 				return FPGA_INVALID_PARAM;
 			}
@@ -103,7 +103,7 @@ fpga_result __FPGA_API__ ase_fpgaReadMMIO32(fpga_handle handle,
 			FPGA_MSG("Misaligned MMIO access");
 			return FPGA_INVALID_PARAM;
 		} else {
-			if (offset > MMIO_AFU_OFFSET) {
+			if (offset > MMIO_AFU_LENGTH) {
 				FPGA_MSG("offset out of bounds");
 				return FPGA_INVALID_PARAM;
 			}
@@ -138,7 +138,7 @@ fpga_result __FPGA_API__ ase_fpgaWriteMMIO64(fpga_handle handle,
 			FPGA_MSG("Misaligned MMIO access");
 			return FPGA_INVALID_PARAM;
 		} else {
-			if (offset > MMIO_AFU_OFFSET) {
+			if (offset > MMIO_AFU_LENGTH) {
 				FPGA_MSG("Offset out of bounds");
 				return FPGA_INVALID_PARAM;
 			}
@@ -171,7 +171,7 @@ fpga_result __FPGA_API__ ase_fpgaReadMMIO64(fpga_handle handle,
 			FPGA_MSG("Misaligned MMIO access");
 			return FPGA_INVALID_PARAM;
 		} else {
-			if (offset > MMIO_AFU_OFFSET) {
+			if (offset > MMIO_AFU_LENGTH) {
 				FPGA_MSG("Offset out of bounds");
 				return FPGA_INVALID_PARAM;
 			}
@@ -205,7 +205,7 @@ fpga_result __FPGA_API__ ase_fpgaWriteMMIO512(fpga_handle handle,
 			FPGA_MSG("Misaligned MMIO access");
 			return FPGA_INVALID_PARAM;
 		} else {
-			if (offset > MMIO_AFU_OFFSET) {
+			if (offset > MMIO_AFU_LENGTH) {
 				FPGA_MSG("Offset out of bounds");
 				return FPGA_INVALID_PARAM;
 			}

--- a/ase/sw/ase_common.h
+++ b/ase/sw/ase_common.h
@@ -104,8 +104,9 @@
 #define CCI_CHUNK_SIZE       (2*1024*1024)	// CCI 2 MB physical chunks
 
 //MMIO memory map size
-#define MMIO_LENGTH                (512*1024)	// 512 KB MMIO size
+#define MMIO_LENGTH                (1024*1024*1024)	// 1 GB MMIO size
 #define MMIO_AFU_OFFSET            (256*1024)
+#define MMIO_AFU_LENGTH            (MMIO_LENGTH-MMIO_AFU_OFFSET)
 
 // MMIO Tid width
 #define MMIO_TID_BITWIDTH          9


### PR DESCRIPTION
An N6000 FIM that expands the MMIO address space to 1GB was created, therefore, extending software MMIO address space correspondingly.