### PR TITLE
Feature - Add fpgaBindSVA() to match OPAE

### DIFF
--- a/ase/api/src/ase.h
+++ b/ase/api/src/ase.h
@@ -70,6 +70,7 @@ fpga_result ase_fpgaPrepareBuffer(fpga_handle handle, uint64_t len,
 fpga_result ase_fpgaReleaseBuffer(fpga_handle handle, uint64_t wsid);
 fpga_result ase_fpgaGetIOAddress(fpga_handle handle, uint64_t wsid,
 				   uint64_t *ioaddr);
+fpga_result ase_fpgaBindSVA(fpga_handle handle, uint32_t *pasid);
 fpga_result ase_fpgaGetOPAECVersion(fpga_version *version);
 fpga_result ase_fpgaGetOPAECVersionString(char *version_str, size_t len);
 fpga_result ase_fpgaGetOPAECBuildString(char *build_str, size_t len);

--- a/ase/api/src/buffer.c
+++ b/ase/api/src/buffer.c
@@ -546,9 +546,6 @@ fpga_result __FPGA_API__ ase_fpgaBindSVA(fpga_handle handle, uint32_t *pasid)
 	fpga_result result = FPGA_OK;
 	int err;
 
-	if (!pasid)
-		return FPGA_INVALID_PARAM;
-
 	result = handle_check_and_lock(_handle);
 	if (result)
 		return result;
@@ -561,7 +558,8 @@ fpga_result __FPGA_API__ ase_fpgaBindSVA(fpga_handle handle, uint32_t *pasid)
 			process_pasid = 1;
 	}
 
-	*pasid = process_pasid;
+	if (pasid)
+		*pasid = process_pasid;
 	_handle->pasid = process_pasid;
 
 	err = pthread_mutex_unlock(&_handle->lock);

--- a/ase/api/src/plugin.c
+++ b/ase/api/src/plugin.c
@@ -103,6 +103,8 @@ int __FPGA_API__ opae_plugin_configure(opae_api_adapter_table *adapter,
 		dlsym(adapter->plugin.dl_handle, "ase_fpgaReleaseBuffer");
 	adapter->fpgaGetIOAddress =
 		dlsym(adapter->plugin.dl_handle, "ase_fpgaGetIOAddress");
+	adapter->fpgaBindSVA =
+		dlsym(adapter->plugin.dl_handle, "ase_fpgaBindSVA");
 	/*
 	**	adapter->fpgaGetOPAECVersion = dlsym(adapter->plugin.dl_handle,
 	*"ase_fpgaGetOPAECVersion");

--- a/ase/api/src/types_int.h
+++ b/ase/api/src/types_int.h
@@ -95,7 +95,8 @@ struct _fpga_handle {
 	void *umsg_virt;	    // umsg Virtual Memory pointer
 	uint64_t umsg_size;	    // umsg Virtual Memory Size
 	uint64_t *umsg_iova;	    // umsg IOVA from driver
-	bool fpgaMMIO_is_mapped;  // is MMIO mapped?
+	int pasid;
+	bool fpgaMMIO_is_mapped;    // is MMIO mapped?
 };
 
 /*


### PR DESCRIPTION
### Description
Allocates a PASID with the same interface as OPAE. Does not yet emulate PCIe ATS/PRS with PASID.

### Collateral (docs, reports, design examples, case IDs):

- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:

### Tests run:
