### PR TITLE
Initial support for PCIe ATS emulation

### DIFF
--- a/ase/api/CMakeLists.txt
+++ b/ase/api/CMakeLists.txt
@@ -66,6 +66,7 @@ target_link_libraries(ase
         ${libuuid_LIBRARIES}
         ${librt_LIBRARIES}
         opae-c
+        opaemem
 )
 
 # Define headers for this library. PUBLIC headers are used for

--- a/ase/sw/pcie_ss_tlp/pcie_ss_tlp_debug.c
+++ b/ase/sw/pcie_ss_tlp/pcie_ss_tlp_debug.c
@@ -58,12 +58,24 @@ const char* pcie_ss_func_fmttype_to_string(uint8_t fmttype)
     return t;
 }
 
+static void fprintf_pcie_ss_prefix(FILE *stream, const t_pcie_ss_hdr_upk *hdr)
+{
+    if (!hdr->pref_present)
+        return;
+
+    if (hdr->pref_type == 0b10001)
+        fprintf(stream, " [pasid 0x%x]", hdr->pref);
+    else
+        fprintf(stream, " [prefix type 0x%x value 0x%x]", hdr->pref_type, hdr->pref);
+}
+
 static void fprintf_pcie_ss_base(FILE *stream, const t_pcie_ss_hdr_upk *hdr)
 {
     fprintf(stream, "%s %s len_bytes 0x%04x",
             pcie_ss_func_fmttype_to_string(hdr->fmt_type),
             (hdr->dm_mode ? "DM" : "PU"),
             hdr->len_bytes);
+    fprintf_pcie_ss_prefix(stream, hdr);
 }
 
 static void fprintf_pcie_ss_mem_req(FILE *stream, const t_pcie_ss_hdr_upk *hdr)

--- a/ase/sw/pcie_ss_tlp/pcie_ss_tlp_hdr.c
+++ b/ase/sw/pcie_ss_tlp/pcie_ss_tlp_hdr.c
@@ -89,6 +89,12 @@ void pcie_ss_tlp_hdr_pack(
     v |= (uint32_t)(hdr->pf_num);
     svPutPartselBit(tdata, v, 32*5, 32);
 
+    v = 0;
+    v |= (uint32_t)(hdr->pref_present) << 29;
+    v |= (uint32_t)(hdr->pref_type) << 24;
+    v |= (uint32_t)(hdr->pref);
+    svPutPartselBit(tdata, v, 32*4, 32);
+
     svPutPartselBit(tdata, hdr->metadata, 32*7, 32);
     svPutPartselBit(tdata, hdr->metadata >> 32, 32*6, 32);
 
@@ -175,6 +181,11 @@ void pcie_ss_tlp_hdr_unpack(
     hdr->vf_active = (v >> 14) & 1;
     hdr->vf_num = (v >> 3) & 0x7ff;
     hdr->pf_num = v & 0x7;
+
+    svGetPartselBit(&v, tdata, 32*4, 32);
+    hdr->pref_present = (v >> 29) & 1;
+    hdr->pref_type = (v >> 24) & 0x1f;
+    hdr->pref = v & 0xffffff;
 
     svGetPartselBit(&v, tdata, 32*7, 32);
     svGetPartselBit(&v1, tdata, 32*6, 32);

--- a/ase/sw/pcie_ss_tlp/pcie_ss_tlp_stream.h
+++ b/ase/sw/pcie_ss_tlp/pcie_ss_tlp_stream.h
@@ -308,6 +308,10 @@ typedef struct
     uint16_t vf_num;
     uint8_t pf_num;
 
+    bool pref_present;
+    uint8_t pref_type;
+    uint32_t pref;
+
     uint16_t req_id;
     uint16_t tag;
 


### PR DESCRIPTION
Update ASE's IOMMU emulation to support two spaces: IOVA and PA. With the update, IOVAs are now assigned using the same library as the real OPAE SDK and vfio. Pinned pages now go through this path, using IOVAs assigned by the library.

For PCIe ATS, ASE now maintains a simulated physical address space that is separate from IOVA. This commit contains the bare minimum for detecting a translation request and responding with a single PA. PRS and invalidation are not yet emulated. munmap() is not tracked yet.