### PR TITLE
[Update] Add emulation of PCIe PRS request and response

### DIFF
--- a/ase/sw/ase_common.h
+++ b/ase/sw/ase_common.h
@@ -363,6 +363,22 @@ typedef struct umsgcmd_t {
 } umsgcmd_t;
 
 
+/*
+ * PCIe message. This encoding is used for page request services and address
+ * invalidation.
+ */
+typedef struct {
+	uint8_t fmt_type;
+	uint8_t msg_code;
+	uint16_t len_bytes;
+	uint16_t req_id;
+	uint32_t msg0;
+	uint32_t msg1;
+	uint32_t msg2;
+    uint16_t tag;
+} ase_pcie_msg_hdr_t;
+
+
 // Compute buffer_t size
 #define BUFSIZE     sizeof(struct buffer_t)
 
@@ -560,7 +576,7 @@ extern "C" {
 #define ASE_MQ_MAXMSG     8
 #define ASE_MQ_MSGSIZE    1024
 #define ASE_MQ_NAME_LEN   64
-#define ASE_MQ_INSTANCES  14
+#define ASE_MQ_INSTANCES  16
 // Message presence setting
 #define ASE_MSG_PRESENT 0xD33D
 #define ASE_MSG_ABSENT  0xDEAD
@@ -775,6 +791,8 @@ extern int sim2app_membus_rd_req_tx;
 extern int app2sim_membus_rd_rsp_rx;
 extern int sim2app_membus_wr_req_tx;
 extern int app2sim_membus_wr_rsp_rx;
+extern int sim2app_pcie_msg_tx;
+extern int app2sim_pcie_msg_rx;
 #endif				// End SIM_SIDE
 
 // There is no global fixes for this

--- a/ase/sw/ase_common.h
+++ b/ase/sw/ase_common.h
@@ -375,7 +375,7 @@ typedef struct {
 	uint32_t msg0;
 	uint32_t msg1;
 	uint32_t msg2;
-    uint16_t tag;
+	uint16_t tag;
 } ase_pcie_msg_hdr_t;
 
 

--- a/ase/sw/ase_host_memory.c
+++ b/ase/sw/ase_host_memory.c
@@ -207,7 +207,7 @@ static inline uint64_t ase_host_memory_gen_xor_mask(int pt_level)
  *
  * Returns -1 on fatal error.
  */
-static int64_t ase_host_memory_va_page_len(uint64_t va)
+int64_t ase_host_memory_va_page_len(uint64_t va)
 {
 	int64_t page_size;
 	char line[4096];
@@ -282,6 +282,8 @@ static int64_t ase_host_memory_va_page_len(uint64_t va)
  */
 uint64_t ase_host_memory_va_to_pa(uint64_t va, uint64_t *length)
 {
+	uint64_t pa = 0;
+
 	if (pthread_mutex_lock(&ase_pt_lock)) {
 		ASE_ERR("pthread_mutex_lock could not attain lock !\n");
 		return INT64_C(-1);
@@ -293,9 +295,11 @@ uint64_t ase_host_memory_va_to_pa(uint64_t va, uint64_t *length)
 	int64_t page_len = ase_host_memory_va_page_len(va);
 	if (page_len == -1)
 		goto err_unlock;
+	if (page_len == 0)
+		goto out_unlock;
 
 	int pt_level = ase_pt_length_to_level(page_len);
-	uint64_t pa = va ^ ase_host_memory_gen_xor_mask(pt_level);
+	pa = va ^ ase_host_memory_gen_xor_mask(pt_level);
 
 	// Is the address already in the table?
 	uint64_t cur_table_va;

--- a/ase/sw/ase_host_memory.h
+++ b/ase/sw/ase_host_memory.h
@@ -177,6 +177,12 @@ void ase_host_memory_unlock(void);
 // The page length is an output.
 uint64_t ase_host_memory_va_to_pa(uint64_t va, uint64_t *length);
 
+// Return the size of the memory page at "va", in bytes. If no memory is mapped
+// at the address return 0.
+//
+// Returns -1 on fatal error.
+int64_t ase_host_memory_va_page_len(uint64_t va);
+
 // Initialize/terminate page address translation.
 int ase_host_memory_initialize(void);
 void ase_host_memory_terminate(void);

--- a/ase/sw/mqueue_ops.c
+++ b/ase/sw/mqueue_ops.c
@@ -41,7 +41,9 @@ struct ipc_t mq_array[ASE_MQ_INSTANCES] = {
 	{ { "sim2app_membus_rd_req_smq" }, { 0, }, 0 },
 	{ { "app2sim_membus_rd_rsp_smq" }, { 0, }, 0 },
 	{ { "sim2app_membus_wr_req_smq" }, { 0, }, 0 },
-	{ { "app2sim_membus_wr_rsp_smq" }, { 0, }, 0 }
+	{ { "app2sim_membus_wr_rsp_smq" }, { 0, }, 0 },
+	{ { "sim2app_pcie_msg_smq"      }, { 0, }, 0 },
+	{ { "app2sim_pcie_msg_smq"      }, { 0, }, 0 }
 };
 
 /*

--- a/ase/sw/pcie_ss_tlp/pcie_ss_tlp_stream.h
+++ b/ase/sw/pcie_ss_tlp/pcie_ss_tlp_stream.h
@@ -257,6 +257,54 @@
 // } PCIe_CplHdr_t;
 //
 
+//
+//
+// PU Encoded messages (ATS invalidation, PRS, etc.):
+//
+// typedef struct packed {
+//     // Byte 31 - Byte 24
+//     logic   [63:0]      rsvd1;              // [DW6 31: 0] Reserved
+//
+//     // Byte 23 - Byte 20
+//     logic   [7:0]       rsvd2;              // [DW5 31:24] Reserved
+//     logic   [4:0]       slot_num;           // [DW5 23:19] Slot Number
+//     logic   [3:0]       bar_number;         // [DW5 18:15] Bar Number
+//     logic               vf_active;          // [DW5 14:14]
+//     logic   [10:0]      vf_num;             // [DW5 13: 3]
+//     logic   [2:0]       pf_num;             // [DW5  2: 0]
+//
+//     // Byte 19 - Byte 16
+//     logic   [1:0]       rsvd3;              // [DW4 31:30] Reserved
+//     logic               pref_present;       // [DW4 29:29] Prefix Present
+//     logic   [4:0]       pref_type;          // [DW4 28:24] Prefix Type
+//     logic   [23:0]      pref;               // [DW4 23:00] Prefix
+//
+//     // Byte 15 - Byte 12
+//     logic   [31:0]      msg2;               // [DW3 31: 0] Message-specific value
+//
+//     // Byte 11 - Byte 8
+//     logic   [31:0]      msg1;               // [DW2 31: 0] Message-specific value
+//
+//     // Byte 7 - Byte 4
+//     logic   [15:0]      req_id;             // [DW1 31:16]
+//     logic   [7:0]       msg0;               // [DW1 15: 8] Message-specific value (tag_l in messages with tags)
+//     logic   [7:0]       msg_code;           // [DW1  7: 0] Message code (see PCIE_MSGCODE_* above)
+//
+//     // Byte 3 - Byte 0
+//     ReqHdr_FmtType_e    fmt_type;           // [DW0 31:24] Specify the type (read/write) - 8 bits wide
+//     logic               tag_h;              // [DW0 23:23] For messages with tags (reserved in others)
+//     logic   [2:0]       TC;                 // [DW0 22:20] Traffic Channel
+//     logic               tag_m;              // [DW0 19:19] For messages with tags (reserved in others)
+//     logic               attr_h;             // [DW0 18:18]
+//     logic   [1:0]       rsvd4;              // [DW0 17:16]
+//     logic               TD;                 // [DW0 15:15]
+//     logic               EP;                 // [DW0 14:14]
+//     logic   [1:0]       attr_l;             // [DW0 13:12]
+//     logic   [1:0]       rsvd5;              // [DW0 11:10]
+//     logic   [9:0]       length;             // [DW0  9: 0] Length in DW
+// } PCIe_PUMsgHdr_t;
+//
+
 // Attributes (read/write requests)
 typedef struct
 {
@@ -297,6 +345,16 @@ typedef struct
 }
 t_pcie_ss_hdr_intr_upk;
 
+// Header fields in PU messages
+typedef struct
+{
+    uint32_t msg2;
+    uint32_t msg1;
+    uint8_t msg0;
+    uint8_t msg_code;
+}
+t_pcie_ss_hdr_msg_upk;
+
 typedef struct
 {
     uint64_t metadata;
@@ -322,6 +380,7 @@ typedef struct
         t_pcie_ss_hdr_req_upk req;
         t_pcie_ss_hdr_cpl_upk cpl;
         t_pcie_ss_hdr_intr_upk intr;
+        t_pcie_ss_hdr_msg_upk msg;
     } u;
 
     bool dm_mode;         // Data mover mode?

--- a/ase/sw/pcie_ss_tlp/pcie_tlp_func.h
+++ b/ase/sw/pcie_ss_tlp/pcie_tlp_func.h
@@ -70,6 +70,14 @@ typedef enum
 }
 t_pcie_fmttype_enum;
 
+typedef enum
+{
+    PCIE_MSGCODE_ATS_INVAL_REQ = B8(00000001), // ATS invalidate request
+    PCIE_MSGCODE_ATS_INVAL_CPL = B8(00000010), // ATS invalidate complation
+    PCIE_MSGCODE_PAGE_REQ      = B8(00000100), // Page request interface - map a page
+    PCIE_MSGCODE_PAGE_RSP      = B8(00000101)  // Page group response
+}
+t_pcie_msgcode_enum;
 
 static inline bool tlp_func_is_addr32(uint8_t fmttype)
 {
@@ -104,6 +112,11 @@ static inline bool func_is_atomic_req (uint8_t fmttype)
 static inline bool func_is_atomic_cas_req (uint8_t fmttype)
 {
     return ((fmttype == PCIE_FMTTYPE_CAS32) || (fmttype == PCIE_FMTTYPE_CAS64));
+}
+
+static inline bool tlp_func_is_msg(uint8_t fmttype)
+{
+    return ((fmttype & 0xb8) == 0x30);
 }
 
 static inline bool tlp_func_is_mem_req(uint8_t fmttype)

--- a/ase/sw/protocol_backend.c
+++ b/ase/sw/protocol_backend.c
@@ -53,6 +53,8 @@ int sim2app_membus_rd_req_tx;
 int app2sim_membus_rd_rsp_rx;
 int sim2app_membus_wr_req_tx;
 int app2sim_membus_wr_rsp_rx;
+int sim2app_pcie_msg_tx;
+int app2sim_pcie_msg_rx;
 static int intr_event_fds[MAX_USR_INTRS];
 
 int glbl_test_cmplt_cnt;                // Keeps the number of session_deinits received
@@ -1329,6 +1331,10 @@ int ase_init(void)
 		mqueue_open(mq_array[12].name, mq_array[12].perm_flag);
 	app2sim_membus_wr_rsp_rx =
 		mqueue_open(mq_array[13].name, mq_array[13].perm_flag);
+	sim2app_pcie_msg_tx =
+		mqueue_open(mq_array[14].name, mq_array[14].perm_flag);
+	app2sim_pcie_msg_rx =
+		mqueue_open(mq_array[15].name, mq_array[15].perm_flag);
 
 	int i;
 
@@ -1463,6 +1469,8 @@ void start_simkill_countdown(void)
 	mqueue_close(app2sim_membus_rd_rsp_rx);
 	mqueue_close(sim2app_membus_wr_req_tx);
 	mqueue_close(app2sim_membus_wr_rsp_rx);
+	mqueue_close(sim2app_pcie_msg_tx);
+	mqueue_close(app2sim_pcie_msg_rx);
 
 	int ipc_iter;
 	for (ipc_iter = 0; ipc_iter < ASE_MQ_INSTANCES; ipc_iter++)


### PR DESCRIPTION
### Description
Two new PCIe messages supported: page request and page request group response. ASE is operating in user space, so the normal PRS allocation of backing storage for a page is invisible. The PRS message does, however, indicate whether a VA is mapped in the address space.

### Collateral (docs, reports, design examples, case IDs):



- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
PIM test suite