### PR TITLE
[Feature] - Add emulation of PCIe ATS invalidation

### DIFF
--- a/ase/api/CMakeLists.txt
+++ b/ase/api/CMakeLists.txt
@@ -40,6 +40,7 @@ set(ASEAPI_SRC
   ${API_DIR}/../sw/ase_ops.c
   ${API_DIR}/../sw/ase_strings.c
   ${API_DIR}/../sw/ase_host_memory.c
+  ${API_DIR}/../sw/ase_pcie_ats.c
   ${API_DIR}/../sw/app_backend.c
   ${API_DIR}/../sw/mqueue_ops.c
   ${API_DIR}/../sw/error_report.c
@@ -69,6 +70,15 @@ target_link_libraries(ase
         opaemem
 )
 
+
+# LD_PRELOAD library that intercepts memory allocation functions, e.g. mmap().
+# ASE models that track the address space have hooks that are called.
+set(ASE_PRELOAD_SRC
+  ${API_DIR}/../sw/preload/mmap_hooks.c)
+
+add_library(ase-preload MODULE ${ASE_PRELOAD_SRC})
+
+
 # Define headers for this library. PUBLIC headers are used for
 # compiling the library, and will be added to consumers' build
 # paths. Keep current directory private.
@@ -91,6 +101,6 @@ set_target_properties(opae-c-ase PROPERTIES
   VERSION ${ASE_VERSION}
   SOVERSION ${ASE_VERSION_MAJOR})
 
-install(TARGETS ase opae-c-ase
+install(TARGETS ase opae-c-ase ase-preload
   LIBRARY DESTINATION ${OPAE_LIB_INSTALL_DIR}
   COMPONENT opaecase)

--- a/ase/scripts/with_ase
+++ b/ase/scripts/with_ase
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 # Run a binary using the ASE simulation library instead of the standard libopae-c.
-env WITH_ASE=1 "$@"
+LD_PRELOAD=libase-preload.so:${LD_PRELOAD} WITH_ASE=1 "$@"

--- a/ase/sw/ase_host_memory.h
+++ b/ase/sw/ase_host_memory.h
@@ -156,6 +156,8 @@ typedef struct {
 
 #ifndef SIM_SIDE
 
+extern bool ase_pt_enable_debug;
+
 // Pin a page at specified virtual address. Allocates and returns
 // an IOVA.
 int ase_host_memory_pin(void *va, uint64_t *iova, uint64_t length);
@@ -182,6 +184,9 @@ uint64_t ase_host_memory_va_to_pa(uint64_t va, uint64_t *length);
 //
 // Returns -1 on fatal error.
 int64_t ase_host_memory_va_page_len(uint64_t va);
+
+// Invalidate virtual range, removing it from the PA->VA tracking table.
+void ase_host_memory_inval_va_range(uint64_t va, uint64_t length);
 
 // Initialize/terminate page address translation.
 int ase_host_memory_initialize(void);

--- a/ase/sw/ase_pcie_ats.c
+++ b/ase/sw/ase_pcie_ats.c
@@ -1,0 +1,196 @@
+// Copyright(c) 2023, Intel Corporation
+//
+// Redistribution  and	use	 in source	and	 binary	 forms,	 with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of	 source code  must retain the  above copyright notice,
+//	 this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//	 this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+// **************************************************************************
+
+//
+// Support functions for PCIe address translation service emulation.
+//
+
+#include <byteswap.h>
+#include <stdio.h>
+#include <stdatomic.h>
+
+#include "ase_common.h"
+#include "ase_pcie_ats.h"
+
+static pthread_mutex_t ase_itag_lock = PTHREAD_MUTEX_INITIALIZER;
+static volatile uint32_t itag_busy_vec;
+static struct {
+    uint64_t set_cycle;
+    int8_t cc_expected;
+    int8_t cc_received;
+} itag_busy_state[32];
+static uint64_t err_check_cycle;
+
+
+/*
+ * Encode a 64 bit physical address, translated from a VA, in a PCIe ATS
+ * completion payload.
+ */
+uint64_t ase_pcie_ats_pa_enc(uint64_t pa, uint64_t page_len, uint32_t flags)
+{
+	// Valid?
+	if (!pa)
+		return 0;
+
+	// Ensure the low 12 flag bits are clear
+	pa &= ~INT64_C(0xfff);
+	// Set the low flag bits
+	pa |= flags;
+
+	// Page size is encoded starting in bit 11 (the S flag) and then a mask of
+	// ones to fill a page. See 10.2.3.2 in the PCIe standard.
+	uint64_t page_mask = (page_len >> 12) - 1;
+	pa |= (page_mask << 11);
+
+	// Swizzle bytes into the required order
+	return bswap_64(pa);
+}
+
+
+/*
+ * Allocate a tag for an ATS invalidation request.
+ */
+int ase_pcie_ats_itag_alloc(void)
+{
+	// Loop until an itag is available. Needing to wait for a free tag should be
+	// rare. Tags are freed by a separate thread that receives messages from the
+	// RTL simulation.
+	while (true) {
+		if (itag_busy_vec != -1) {
+			if (pthread_mutex_lock(&ase_itag_lock)) {
+				ASE_ERR("pthread_mutex_lock could not attain the lock!\n");
+				return -1;
+			}
+
+			int free_itag = __builtin_ffs(~itag_busy_vec);
+
+			// ffs returns bit index + 1, so no tags are available if it's 0.
+			if (free_itag) {
+				free_itag -= 1;
+				itag_busy_state[free_itag].cc_expected = -1;
+				itag_busy_state[free_itag].cc_received = -1;
+				itag_busy_state[free_itag].set_cycle = err_check_cycle;
+
+				// Ensure set_cycle is updated before the busy vector is set
+				__sync_synchronize();
+				itag_busy_vec |= (1 << free_itag);
+
+				pthread_mutex_unlock(&ase_itag_lock);
+				return free_itag;
+			}
+
+			pthread_mutex_unlock(&ase_itag_lock);
+		}
+	}
+}
+
+
+/*
+ * Free one or more ATS invalidation tags. The argument is the vector of
+ * tag bits from the response header. Returns < 0 on error.
+ */
+int ase_pcie_ats_itag_free(uint32_t tag_vec, uint32_t cc)
+{
+	if (pthread_mutex_lock(&ase_itag_lock)) {
+		ASE_ERR("pthread_mutex_lock could not attain the lock!\n");
+		return -1;
+	}
+
+	// cc of 0 means 8
+	if (cc == 0)
+		cc = 8;
+
+	// Loop through all 32 possible tags
+	for (int t = 0; t < 32; t += 1) {
+		if (tag_vec & 1) {
+			if (0 == (itag_busy_vec & (1 << t))) {
+				ASE_ERR("ase_pcie_ats_itag_free: released itag %d is not busy!", t);
+				goto out_err;
+			}
+
+			// First response? Learn the cc value.
+			if (itag_busy_state[t].cc_expected == -1) {
+				itag_busy_state[t].cc_expected = cc;
+				itag_busy_state[t].cc_received = 1;
+			} else {
+				itag_busy_state[t].cc_received += 1;
+
+				if (itag_busy_state[t].cc_expected != cc) {
+					ASE_ERR("ase_pcie_ats_itag_free: cc must be the same on all responses (%d, expected %d)\n",
+						cc, itag_busy_state[t].cc_expected);
+					goto out_err;
+				}
+			}
+
+			if (itag_busy_state[t].cc_received == cc) {
+				// Release the tag
+				itag_busy_vec ^= (1 << t);
+			}
+		}
+
+		// Next tag, early exit if there are no more set in the vector
+		tag_vec >>= 1;
+		if (!tag_vec)
+			break;
+	}
+
+	pthread_mutex_unlock(&ase_itag_lock);
+	return 0;
+
+out_err:
+	pthread_mutex_unlock(&ase_itag_lock);
+	return -1;
+}
+
+
+/*
+ * Check whether an ATS invalidation has been outstanding for too long.
+ * Returns -1 on error.
+ */
+int ase_pcie_ats_itag_cycle(void)
+{
+	int t = 0;
+	uint32_t busy_vec = itag_busy_vec;
+
+	atomic_fetch_add(&err_check_cycle, 1);
+
+	// The itag_busy_vec and itag_busy_state[].set_cycle are managed such
+	// that locking isn't required here.
+	while (busy_vec) {
+		if (busy_vec & 1) {
+			if (err_check_cycle - itag_busy_state[t].set_cycle > 10000) {
+				ASE_ERR("PCIe ATS invalidation request has no completion (itag %d)\n", t);
+				return -1;
+			}
+		}
+
+		t += 1;
+		busy_vec >>= 1;
+	}
+
+	return 0;
+}

--- a/ase/sw/ase_pcie_ats.h
+++ b/ase/sw/ase_pcie_ats.h
@@ -1,0 +1,50 @@
+// Copyright(c) 2023, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+// **************************************************************************
+
+//
+// Support functions for PCIe address translation service emulation.
+//
+
+#ifndef _ASE_PCIE_ATS_H_
+#define _ASE_PCIE_ATS_H_
+
+// Encode a page address and size for PCIe ATS messages, both ATS completions
+// and invalidation requests.
+uint64_t ase_pcie_ats_pa_enc(uint64_t pa, uint64_t page_len, uint32_t flags);
+
+// Allocate a tag for an ATS invalidation request.
+int ase_pcie_ats_itag_alloc(void);
+
+// Free one or more ATS invalidation tags. The argument is the vector of
+// tag bits from the response header. Returns < 0 on error.
+int ase_pcie_ats_itag_free(uint32_t tag_vec, uint32_t cc);
+
+// Check whether an ATS invalidation has been outstanding for too long.
+// Returns -1 on error.
+int ase_pcie_ats_itag_cycle(void);
+
+#endif // _ASE_PCIE_ATS_H_

--- a/ase/sw/pcie_ss_tlp/pcie_ss_tlp_debug.c
+++ b/ase/sw/pcie_ss_tlp/pcie_ss_tlp_debug.c
@@ -114,10 +114,12 @@ static void fprintf_pcie_ss_msg(FILE *stream, const t_pcie_ss_hdr_upk *hdr)
     switch (hdr->u.msg.msg_code)
     {
       case PCIE_MSGCODE_ATS_INVAL_REQ:
-        fprintf(stream, " ats_inval_req");
+        fprintf(stream, " ats_inval_req dev_id 0x%04x itag 0x%x",
+                hdr->u.msg.msg1 >> 16, hdr->u.msg.msg0 & 0x1f);
         break;
       case PCIE_MSGCODE_ATS_INVAL_CPL:
-        fprintf(stream, " ats_inval_cpl");
+        fprintf(stream, " ats_inval_cpl dev_id 0x%04x cc %d itag_vec 0x%x",
+                hdr->u.msg.msg1 >> 16, hdr->u.msg.msg1 & 0x7, hdr->u.msg.msg2);
         break;
       case PCIE_MSGCODE_PAGE_REQ:
         fprintf(stream, " page_req tag 0x%02x addr 0x%08x%08x gidx 0x%x lwr 0x%x",

--- a/ase/sw/preload/mmap_hooks.c
+++ b/ase/sw/preload/mmap_hooks.c
@@ -1,0 +1,155 @@
+// Copyright(c) 2023, Intel Corporation
+//
+// Redistribution  and	use	 in source	and	 binary	 forms,	 with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of	 source code  must retain the  above copyright notice,
+//	 this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//	 this list of conditions and the following disclaimer in the documentation
+//	 and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation	 nor the names of its contributors
+//	 may be used to	 endorse or promote	 products derived  from this  software
+//	 without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.	IN NO EVENT	 SHALL THE COPYRIGHT OWNER	OR CONTRIBUTORS BE
+// LIABLE  FOR	ANY	 DIRECT,  INDIRECT,	 INCIDENTAL,  SPECIAL,	EXEMPLARY,	OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,	BUT	 NOT LIMITED  TO,  PROCUREMENT	OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,	DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY	 OF LIABILITY,	WHETHER IN
+// CONTRACT,  STRICT LIABILITY,	 OR TORT  (INCLUDING NEGLIGENCE	 OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,	EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/*
+ * Interposer for mmap() et. al. to detect changes to the address space for
+ * ASE's PCIe ATS emulation.
+ */
+
+#define _GNU_SOURCE
+
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/mman.h>
+
+static void* (*real_mmap)(void *addr, size_t length, int prot, int flags, int fd, off_t offset);
+static int (*real_munmap)(void *addr, size_t length);
+static void* (*real_mremap)(void *start, size_t old_len, size_t len, int flags, ...);
+
+static void *libase_handle;
+static void (*dl_ase_mem_unmap_hook)(void *va, size_t length);
+
+/*
+ * Find ASE notifier hooks that will be called to tell ASE about memory updates.
+ */
+static void load_ase_hooks(void)
+{
+	static int attempts;
+
+	// Already loaded?
+	if (libase_handle)
+		return;
+
+	// Give up after a while. libase is loaded dynamically, so don't give up
+	// immediately.
+	if (attempts > 1000)
+		return;
+	attempts += 1;
+
+	// Look for ASE, find it only if already loaded into the process
+	libase_handle = dlopen("libase.so", RTLD_LAZY | RTLD_NOLOAD);
+	if (!libase_handle)
+		return;
+
+	dl_ase_mem_unmap_hook = dlsym(libase_handle, "ase_mem_unmap_hook");
+}
+
+
+/*
+ * Wrap mmap() in case addr was specified and overwrites a previous mapping.
+ */
+void __attribute__((visibility("default"))) *
+mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset)
+{
+	if (!real_mmap)
+		real_mmap = dlsym(RTLD_NEXT, "mmap");
+
+	load_ase_hooks();
+
+	if (real_mmap)
+	{
+		if (addr && dl_ase_mem_unmap_hook)
+			(*dl_ase_mem_unmap_hook)(addr, length);
+
+		return (*real_mmap)(addr, length, prot, flags, fd, offset);
+	}
+
+	errno = EINVAL;
+	return MAP_FAILED;
+}
+
+/*
+ * Invalidate translation cache of unmapped region.
+ */
+int __attribute__((visibility("default")))
+munmap(void *addr, size_t length)
+{
+	if (!real_munmap)
+		real_munmap = dlsym(RTLD_NEXT, "munmap");
+
+	load_ase_hooks();
+
+	if (real_munmap)
+	{
+		if (dl_ase_mem_unmap_hook)
+			(*dl_ase_mem_unmap_hook)(addr, length);
+
+		return (*real_munmap)(addr, length);
+	}
+
+	errno = EINVAL;
+	return -1;
+}
+
+/*
+ * Invalidate translation cache of remapped region.
+ */
+void  __attribute__((visibility("default"))) *
+mremap (void *start, size_t old_len, size_t len, int flags, ...)
+{
+	void *result = NULL;
+	va_list ap;
+
+	va_start (ap, flags);
+	void *newaddr = (flags & MREMAP_FIXED) ? va_arg (ap, void *) : NULL;
+	va_end (ap);
+
+	if (!real_mremap)
+		real_mremap = dlsym(RTLD_NEXT, "mremap");
+
+	load_ase_hooks();
+
+	if (real_mremap)
+	{
+		if (dl_ase_mem_unmap_hook)
+			(*dl_ase_mem_unmap_hook)(start, old_len);
+
+		if (flags & MREMAP_FIXED) {
+			if (dl_ase_mem_unmap_hook)
+				(*dl_ase_mem_unmap_hook)(newaddr, len);
+
+			return (*real_mremap)(start, old_len, len, flags, newaddr);
+		}
+		else
+			return (*real_mremap)(start, old_len, len, flags);
+	}
+
+	errno = EINVAL;
+	return MAP_FAILED;
+}


### PR DESCRIPTION
- New LD_PRELOAD library that detects munmap() calls a hook in ASE to trigger invalidation. The LD_PRELOAD is set by "with_ase".
- Generate ATS invalidation requests, handle responses.
- Timeout when invalidation responses don't arrive, raising an error. The same error on HW can crash a host.
