### PR TITLE
[Feature] - Add multi-VF support to ASE

### DIFF
--- a/ase/api/src/buffer.c
+++ b/ase/api/src/buffer.c
@@ -388,7 +388,7 @@ fpga_result __FPGA_API__ ase_fpgaPrepareBuffer(fpga_handle handle, uint64_t len,
 	/* Simulated equivalent of pinning the page */
 	uint64_t dma_map_iova;
 
-	if (ase_host_memory_pin(addr, &dma_map_iova, len) != 0) {
+	if (ase_host_memory_pin(_handle->afu_idx, addr, &dma_map_iova, len) != 0) {
 		if (!preallocated) {
 			buffer_release(addr, len);
 		}
@@ -467,7 +467,7 @@ fpga_result __FPGA_API__ ase_fpgaReleaseBuffer(fpga_handle handle, uint64_t wsid
 	bool preallocated = (wm->flags & FPGA_BUF_PREALLOCATED);
 
 	/* Simulated equivalent of unpinning the page */
-	if (ase_host_memory_unpin(iova, len) != 0) {
+	if (ase_host_memory_unpin(_handle->afu_idx, iova, len) != 0) {
 		if (!preallocated) {
 			buffer_release(buf_addr, len);
 		}

--- a/ase/api/src/mmio.c
+++ b/ase/api/src/mmio.c
@@ -73,7 +73,7 @@ fpga_result __FPGA_API__ ase_fpgaWriteMMIO32(fpga_handle handle,
 				return FPGA_INVALID_PARAM;
 			}
 
-			mmio_write32(offset, value);
+			mmio_write32(offset, _handle->afu_idx, value);
 			return FPGA_OK;
 		}
 	}
@@ -108,7 +108,7 @@ fpga_result __FPGA_API__ ase_fpgaReadMMIO32(fpga_handle handle,
 				return FPGA_INVALID_PARAM;
 			}
 
-			mmio_read32(offset, value);
+			mmio_read32(offset, _handle->afu_idx, value);
 			return FPGA_OK;
 		}
 	}
@@ -142,7 +142,7 @@ fpga_result __FPGA_API__ ase_fpgaWriteMMIO64(fpga_handle handle,
 				FPGA_MSG("Offset out of bounds");
 				return FPGA_INVALID_PARAM;
 			}
-			mmio_write64(offset, value);
+			mmio_write64(offset, _handle->afu_idx, value);
 			return FPGA_OK;
 		}
 	}
@@ -175,7 +175,7 @@ fpga_result __FPGA_API__ ase_fpgaReadMMIO64(fpga_handle handle,
 				FPGA_MSG("Offset out of bounds");
 				return FPGA_INVALID_PARAM;
 			}
-			mmio_read64(offset, (uint64_t *) value);
+			mmio_read64(offset, _handle->afu_idx, (uint64_t *) value);
 			return FPGA_OK;
 		}
 	}
@@ -210,7 +210,7 @@ fpga_result __FPGA_API__ ase_fpgaWriteMMIO512(fpga_handle handle,
 				return FPGA_INVALID_PARAM;
 			}
 
-			mmio_write512(offset, value);
+			mmio_write512(offset, _handle->afu_idx, value);
 			return FPGA_OK;
 		}
 	}

--- a/ase/api/src/open.c
+++ b/ase/api/src/open.c
@@ -32,6 +32,7 @@
 #include <opae/utils.h>
 #include "common_int.h"
 #include "types_int.h"
+#include "token.h"
 #include <ase_common.h>
 
 #include <string.h>
@@ -93,6 +94,14 @@ fpga_result __FPGA_API__ ase_fpgaOpen(fpga_token token, fpga_handle *handle, int
 
 	// Init workspace table
 	_handle->wsid_root = wsid_tracker_init(NUM_WSID_TRACKER_BUCKETS);
+
+	_handle->afu_idx = 0;
+	// VFIO variant supports multiple AFU ports, emulated as VFs
+	if (_token->hdr.subsystem_device_id == ASE_VF0_SUBSYSTEM_DEVICE)
+		_handle->afu_idx = _token->hdr.function - ASE_VF0_FUNCTION;
+
+	// Track open AFUs
+	ase_open_afus_by_tok_idx |= UINT64_C(1) << _token->idx;
 
 	// set handle return value
 	*handle = (void *)_handle;

--- a/ase/api/src/token.h
+++ b/ase/api/src/token.h
@@ -24,56 +24,19 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-static struct _fpga_token aseToken[3] = {
-	{
-		{
-			.magic = ASE_TOKEN_MAGIC,
-			.vendor_id = 0x8086,
-			.device_id = ASE_ID,
-			.segment = 0,
-			.bus = ASE_BUS,
-			.device = ASE_DEVICE,
-			.function = ASE_PF0_FUNCTION,
-			.interface = FPGA_IFC_SIM_DFL,
-			.objtype = FPGA_DEVICE,
-			.object_id = ASE_PF0_FME_OBJID,
-			.guid = { 0, },
-			.subsystem_vendor_id = 0x8086,
-			.subsystem_device_id = ASE_PF0_SUBSYSTEM_DEVICE
-		},
-	},
-	{
-		{
-			.magic = ASE_TOKEN_MAGIC,
-			.vendor_id = 0x8086,
-			.device_id = ASE_ID,
-			.segment = 0,
-			.bus = ASE_BUS,
-			.device = ASE_DEVICE,
-			.function = ASE_PF0_FUNCTION,
-			.interface = FPGA_IFC_SIM_DFL,
-			.objtype = FPGA_ACCELERATOR,
-			.object_id = ASE_PF0_PORT_OBJID,
-			.guid = { 0, },
-			.subsystem_vendor_id = 0x8086,
-			.subsystem_device_id = ASE_PF0_SUBSYSTEM_DEVICE
-		},
-	},
-	{
-		{
-			.magic = ASE_TOKEN_MAGIC,
-			.vendor_id = 0x8086,
-			.device_id = ASE_ID,
-			.segment = 0,
-			.bus = ASE_BUS,
-			.device = ASE_DEVICE,
-			.function = ASE_VF0_FUNCTION,
-			.interface = FPGA_IFC_SIM_VFIO,
-			.objtype = FPGA_ACCELERATOR,
-			.object_id = ASE_VF0_PORT_OBJID,
-			.guid = { 0, },
-			.subsystem_vendor_id = 0x8086,
-			.subsystem_device_id = ASE_VF0_SUBSYSTEM_DEVICE
-		},
-	}
-};
+#ifndef __FPGA_ASE_TOKEN_H__
+#define __FPGA_ASE_TOKEN_H__
+
+#include "types_int.h"
+
+// This must be no larger than 64 because a token index becomes an AFU
+// index and AFU indices are tracked as a bit mask in ase_afu_idx_mask.
+#define ASE_MAX_TOKENS 32
+
+extern int aseNumTokens;
+extern struct _fpga_token aseToken[ASE_MAX_TOKENS];
+
+typedef uint64_t ase_afu_idx_mask;
+extern ase_afu_idx_mask ase_open_afus_by_tok_idx;
+
+#endif // __FPGA_ASE_TOKEN_H__

--- a/ase/api/src/types_int.h
+++ b/ase/api/src/types_int.h
@@ -34,6 +34,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <opae/access.h>
 #include <opae/types_enum.h>
 
 #define ASE_BBSID 0x63000023b637277UL
@@ -81,6 +82,7 @@
 
 /** System-wide unique FPGA resource identifier */
 struct _fpga_token {
+	int idx;		// Index of base device token in aseToken[]
 	fpga_token_header hdr;
 };
 
@@ -96,6 +98,9 @@ struct _fpga_handle {
 	uint64_t umsg_size;	    // umsg Virtual Memory Size
 	uint64_t *umsg_iova;	    // umsg IOVA from driver
 	int pasid;
+	int afu_idx;		    // ASE SW side sees only a vector of
+				    // AFU ports. These are mapped to PF/VF
+				    // on the HW emulation side.
 	bool fpgaMMIO_is_mapped;    // is MMIO mapped?
 };
 

--- a/ase/sw/ase_common.h
+++ b/ase/sw/ase_common.h
@@ -350,6 +350,8 @@ typedef struct mmio_t {
 	int32_t slot_idx;	// Unique scoreboard slot index (less than
 						// MMIO_MAX_OUTSTANDING). Tid is also unique,
 						// but in a larger space.
+	int32_t afu_idx;	// Emulated AFU index. The FPGA-side emulation
+						// will turn this into a PF/VF number.
 } mmio_t;
 
 
@@ -371,10 +373,12 @@ typedef struct {
 	uint8_t fmt_type;
 	uint8_t msg_code;
 	uint16_t len_bytes;
-	uint16_t req_id;
 	uint32_t msg0;
 	uint32_t msg1;
 	uint32_t msg2;
+	int32_t afu_idx;	// Emulated AFU index. The FPGA-side emulation
+	                    // will turn this into a PF/VF number.
+	uint16_t req_id;
 	uint16_t tag;
 } ase_pcie_msg_hdr_t;
 
@@ -528,11 +532,11 @@ extern "C" {
 	uint32_t generate_mmio_tid(void);
 	int mmio_request_put(struct mmio_t *);
 	void mmio_response_get(struct mmio_t *);
-	void mmio_write32(int, uint32_t);
-	void mmio_write64(int, uint64_t);
-	void mmio_read32(int, uint32_t *);
-	void mmio_read64(int, uint64_t *);
-	void mmio_write512(int, const void *);
+	void mmio_write32(int, int, uint32_t);
+	void mmio_write64(int, int, uint64_t);
+	void mmio_read32(int, int, uint32_t *);
+	void mmio_read64(int, int, uint64_t *);
+	void mmio_write512(int, int, const void *);
 
 	// UMSG functions
 	// uint64_t *umsg_get_address(int);


### PR DESCRIPTION
### Description
PCIe SS versions of ASE already include a PF/VF MUX. This update emulates AFU ports as VFs of PF0.

- Port discovery enumerates AFU UUIDs on all VFs.
- The standard OPAE UUID search will find an AFU on any VF.
- Multiple VFs may be open simultaneously.
- IOVA mappings are associated with particular VFs.
- Remove IOVA mappings for at fpgaClose().
- Print emulated B:D:F and GUID of discovered AFUs.
- Legacy CCI-P and OFS EA variants remain limited to one port.

### Collateral (docs, reports, design examples, case IDs):



- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
host_exerciser, afu_examples, PIM tests